### PR TITLE
Add CreateMapTasks Helper & Update Coordinator Initialization

### DIFF
--- a/src/harveytest/mrcoordinator_test.go
+++ b/src/harveytest/mrcoordinator_test.go
@@ -189,6 +189,33 @@ func TestGetTaskHandlerConcurrency(t *testing.T) {
 	}
 }
 
+func TestCreateMapTasks(t *testing.T) {
+    files := []string{"file1.txt", "file2.txt", "file3.txt"}
+    expectedTasks := []*mr.MapTask{
+        {ID: 0, Status: "notstarted", Filename: "file1.txt"},
+        {ID: 1, Status: "notstarted", Filename: "file2.txt"},
+        {ID: 2, Status: "notstarted", Filename: "file3.txt"},
+    }
+
+    tasks := mr.CreateMapTasks(files)
+
+    if len(tasks) != len(expectedTasks) {
+        t.Fatalf("expected %d tasks, got %d", len(expectedTasks), len(tasks))
+    }
+
+    for i, task := range tasks {
+        if task.ID != expectedTasks[i].ID {
+            t.Errorf("expected task ID %d, got %d", expectedTasks[i].ID, task.ID)
+        }
+        if task.Status != expectedTasks[i].Status {
+            t.Errorf("expected task Status %s, got %s", expectedTasks[i].Status, task.Status)
+        }
+        if task.Filename != expectedTasks[i].Filename {
+            t.Errorf("expected task Filename %s, got %s", expectedTasks[i].Filename, task.Filename)
+        }
+    }
+}
+
 // helpers
 func mockCoordinator(state string, mapTasks []*mr.MapTask, reduceTasks []*mr.ReduceTask) *mr.Coordinator {
     return &mr.Coordinator{

--- a/src/mr/coordinator.go
+++ b/src/mr/coordinator.go
@@ -148,10 +148,25 @@ func (c *Coordinator) Done() bool {
 // main/mrcoordinator.go calls this function.
 // nReduce is the number of reduce tasks to use.
 func MakeCoordinator(files []string, nReduce int) *Coordinator {
-	c := Coordinator{}
-	// Your code here.
+	c := Coordinator{
+        MapTasks: CreateMapTasks(files),
+        ReduceTasks: []*ReduceTask{},
+        NReduce: nReduce,
+        State: "map",
+    }
 
 	c.server()
 	return &c
 }
 
+func CreateMapTasks(files []string) []*MapTask {
+    tasks := []*MapTask{}
+    for i, file := range(files) {
+        tasks = append(tasks, &MapTask{
+            ID: i,
+            Status: "notstarted",
+            Filename: file,
+        })
+    }
+    return tasks
+}


### PR DESCRIPTION
### Summary
This PR introduces a helper function, `CreateMapTasks`, that initializes map tasks based on a list of input files. The changes ensure that each input file is wrapped in a `MapTask` struct with a unique ID and an initial status of `"notstarted"`. The coordinator is updated to use this helper when it is instantiated. A new unit test (`TestCreateMapTasks`) verifies that the helper function creates the expected tasks.

### Changes:
- **Coordinator Initialization:**  
  - Updated the `MakeCoordinator` function in `src/mr/coordinator.go` to initialize the `MapTasks` field using the new `CreateMapTasks` helper.
  - The coordinator now also sets its initial state to `"map"` and initializes the `ReduceTasks` slice and `NReduce` count.

- **CreateMapTasks Helper Function:**  
  - Added the `CreateMapTasks` function which iterates over the provided input files and creates a slice of pointers to `MapTask`.
  - Each `MapTask` is created with:
    - `ID` corresponding to the file’s index,
    - `Status` set to `"notstarted"`, and
    - `Filename` set to the file's name.

- **Testing:**  
  - Added `TestCreateMapTasks` to ensure that `CreateMapTasks` returns the correct number of tasks with expected values.
  - The test checks for the correct task ID, status, and filename for each task.

### Impact:
- **Clarity & Maintainability:**  
  By encapsulating the creation logic of map tasks into a dedicated helper function, the code in `MakeCoordinator` becomes cleaner and more maintainable.
- **Testability:**  
  The new unit test provides immediate feedback if the task creation logic deviates from expected behavior.